### PR TITLE
[Fix] 소셜 로그인 연동 및 백엔드 OAuth2 프록시 설정

### DIFF
--- a/apps/web/components/login/SocialButton.tsx
+++ b/apps/web/components/login/SocialButton.tsx
@@ -121,8 +121,8 @@ export default function SocialButton({ provider }: SocialButtonProps) {
       isSecure ? '; Secure' : ''
     }`;
 
-    // 4. BFF 소셜 로그인 엔드포인트로 이동
-    window.location.href = `/api/auth/${provider}`;
+    // 4. Next.js가 백엔드로 프록시해주는 OAuth2 인증 시작 경로로 이동
+    window.location.href = `/oauth2/authorization/${provider}`;
   };
 
   return (

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -16,6 +16,18 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      {
+        source: '/oauth2/:path*',
+        destination: `${process.env.BACKEND_URL}/oauth2/:path*`,
+      },
+      {
+        source: '/login/oauth2/:path*',
+        destination: `${process.env.BACKEND_URL}/login/oauth2/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 1. 개요
소셜 로그인 버튼 클릭 시 백엔드의 OAuth2 인증 시스템과 직접 통신할 수 있도록 프록시 환경을 구축하고 관련 컴포넌트 로직을 업데이트했습니다.

## 2. 주요 변경 사항

### 2.1 OAuth2 프록시 설정 (`next.config.ts`)
- 백엔드의 인증 엔드포인트에 접근하기 위한 `rewrites` 규칙을 추가했습니다.
  - `/oauth2/:path*` → `${BACKEND_URL}/oauth2/:path*` (인증 시작)
  - `/login/oauth2/:path*` → `${BACKEND_URL}/login/oauth2/:path*` (콜백 처리)
- 이를 통해 브라우저에서 백엔드 도메인을 직접 노출하지 않고도 인증 흐름을 진행할 수 있습니다.

### 2.2 로그인 버튼 로직 수정 (`SocialButton.tsx`)
- 로그인 트리거 경로를 기존 BFF API (`/api/auth/${provider}`)에서 프록시 경로 (`/oauth2/authorization/${provider}`)로 변경했습니다.
- Next.js의 리라이트 기능을 활용하여 인증 흐름을 보다 직관적이고 단순하게 개선했습니다.

## 3. 배경 및 영향
- **유연성**: `BACKEND_URL` 환경 변수를 통해 개발/스테이징/운영 서버의 백엔드 주소를 동적으로 관리할 수 있습니다.
- **단순화**: 복잡한 BFF 처리 과정을 줄이고 백엔드의 표준 OAuth2 흐름을 그대로 활용하여 유지보수성을 높였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced OAuth2 authentication flow infrastructure with updated endpoint routing and cookie management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->