### PR TITLE
[Refactor] 서버리스 환경 대응을 위한 동적 호스트 탐지 및 BFF 헤더 최적화

### DIFF
--- a/apps/web/lib/api/backend.ts
+++ b/apps/web/lib/api/backend.ts
@@ -13,16 +13,19 @@ interface BffInfo {
   isLocal: boolean;
 }
 
-function getBffInfo(request?: NextRequest): BffInfo {
+function getBffInfo(
+  request?: NextRequest,
+  overrides?: { host?: string; proto?: string; port?: string },
+): BffInfo {
   const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || '';
 
   if (!backendUrl && typeof window === 'undefined') {
     throw new Error('[BFF] BACKEND_URL 환경변수가 설정되지 않았습니다.');
   }
 
-  let host = process.env.BFF_HOST || process.env.NEXT_PUBLIC_BFF_HOST;
-  let proto = process.env.BFF_PROTO || process.env.NEXT_PUBLIC_BFF_PROTO;
-  let port = process.env.BFF_PORT || process.env.NEXT_PUBLIC_BFF_PORT;
+  let host = overrides?.host;
+  let proto = overrides?.proto;
+  let port = overrides?.port;
 
   if (request) {
     const isSecure = request.nextUrl.protocol === 'https:';
@@ -36,9 +39,17 @@ function getBffInfo(request?: NextRequest): BffInfo {
     port = port || window.location.port || (isSecure ? '443' : '80');
   }
 
-  host = host || 'localhost:3000';
-  proto = (proto || 'http').replace(':', '');
-  port = port || '3000';
+  // 기본값 할당 (모든 탐지 실패 시)
+  host = host || 'localhost';
+  proto = proto || 'http';
+  port = port || (proto === 'https' ? '443' : '3000');
+
+  // 호스트 문자열에 포트가 포함된 경우(예: localhost:3000) 분리
+  if (host.includes(':')) {
+    const [h, p] = host.split(':');
+    host = h;
+    port = p;
+  }
 
   const isLocal = host.startsWith('localhost') || host.startsWith('127.0.0.1') || proto === 'http';
 
@@ -107,8 +118,8 @@ export async function fetchBackend(
   options: RequestInit & { bffRequest?: NextRequest } = {},
 ): Promise<Response> {
   const { bffRequest, ...fetchOptions } = options;
-  const bffInfo = getBffInfo(bffRequest);
 
+  const dynamicOverrides: { host?: string; proto?: string; port?: string } = {};
   const extraHeaders: Record<string, string> = { Accept: 'application/json' };
 
   if (!bffRequest) {
@@ -116,6 +127,22 @@ export async function fetchBackend(
       const { cookies, headers } = await import('next/headers');
       const cookieList = await cookies();
       const headerList = await headers();
+
+      // 동적 호스트 및 프로토콜 감지 (Vercel/Next.js Proxy Headers 대응)
+      const host = headerList.get('x-forwarded-host') || headerList.get('host');
+      const proto = headerList.get('x-forwarded-proto');
+
+      if (host) {
+        dynamicOverrides.host = host;
+        // 호스트 문자열에 포트가 포함되어 있는지 확인
+        if (host.includes(':')) {
+          const [h, p] = host.split(':');
+          dynamicOverrides.host = h;
+          dynamicOverrides.port = p;
+        }
+      }
+      if (proto) dynamicOverrides.proto = proto.replace(':', '');
+
       const cookie = cookieList.toString();
       if (cookie) extraHeaders['Cookie'] = cookie;
       const ua = headerList.get('user-agent');
@@ -127,6 +154,8 @@ export async function fetchBackend(
     const cookie = bffRequest.headers.get('cookie');
     if (cookie) extraHeaders['Cookie'] = cookie;
   }
+
+  const bffInfo = getBffInfo(bffRequest, dynamicOverrides);
 
   const finalHeaders = buildBffHeaders(bffInfo, {
     ...extraHeaders,

--- a/apps/web/lib/api/backend.ts
+++ b/apps/web/lib/api/backend.ts
@@ -129,19 +129,19 @@ export async function fetchBackend(
       const headerList = await headers();
 
       // 동적 호스트 및 프로토콜 감지 (Vercel/Next.js Proxy Headers 대응)
-      const host = headerList.get('x-forwarded-host') || headerList.get('host');
-      const proto = headerList.get('x-forwarded-proto');
+      const hostValue = headerList.get('x-forwarded-host') || headerList.get('host');
+      const protoValue = headerList.get('x-forwarded-proto');
 
-      if (host) {
-        dynamicOverrides.host = host;
-        // 호스트 문자열에 포트가 포함되어 있는지 확인
-        if (host.includes(':')) {
-          const [h, p] = host.split(':');
-          dynamicOverrides.host = h;
-          dynamicOverrides.port = p;
-        }
+      if (hostValue) {
+        // Multi-proxy 체인 대응: 첫 번째 호스트 사용
+        dynamicOverrides.host = hostValue.split(',')[0].trim();
       }
-      if (proto) dynamicOverrides.proto = proto.replace(':', '');
+
+      if (protoValue) {
+        // Multi-proxy 체인 대응: 마지막 프로토콜 사용
+        const protos = protoValue.split(',');
+        dynamicOverrides.proto = protos[protos.length - 1].trim().replace(':', '');
+      }
 
       const cookie = cookieList.toString();
       if (cookie) extraHeaders['Cookie'] = cookie;


### PR DESCRIPTION
## 변경 사유

기존 BFF 구조는 `BFF_HOST`, `BFF_PROTO` 등의 환경변수를 수동으로 설정해야 했습니다. 하지만 Vercel과 같은 서버리스 배포 환경에서는 다음과 같은 문제와 한계가 존재했습니다.

1.  **Vercel Preview Deployment 대응 불가능**: Vercel은 PR마다 고유한 URL(예: `*-git-branch.vercel.app`)을 생성합니다. 환경변수에 운영 도메인을 고정해두면, Preview 주소에서 발생하는 요청도 운영 도메인으로 인식되어 백엔드와의 **쿠키 도메인 정합성**이 깨지거나 **CORS 설정**이 꼬이는 문제가 발생했습니다.
2.  **환경변수 관리의 어려움**: 로컬(3000), 개발(Preview), 운영 환경마다 매번 다른 호스트 설정값을 관리해야 하는 번거로움이 있었습니다.
3.  **포트 인식 문제**: 로컬 환경(`:3000`)과 운영 환경(`:443`) 간의 포트 차이를 수동으로 처리하던 로직이 서버사이드 액션(Server Actions) 등에서 일관되지 않게 동작할 위험이 있었습니다.

## 해결 방법

Next.js 15의 `headers()` 기능을 활용하여 **현재 실행 중인 요청의 컨텍스트를 실시간으로 추출**하도록 `fetchBackend` 유틸리티를 개선했습니다.

*   **`x-forwarded-host` 활용**: Vercel/Next.js Proxy가 자동으로 주입하는 표준 헤더를 참조하여, 현재 사용자가 접속 중인 실제 도메인을 추출합니다.
*   **동적 프로토콜 인식**: HTTPS 환경(Vercel)과 HTTP 환경(Local)을 자동으로 구분하여 `X-BFF-Proto` 및 `X-BFF-Port`를 구성합니다.
*   **Fallback**: 서버사이드에서 직접 실행되어 헤더를 읽을 수 없는 특수한 상황을 대비해 기본값(Localhost) 설정을 포함했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved handling of backend API routing for applications deployed behind reverse proxies or load balancers. The application now correctly detects and applies forwarded host, protocol, and port information from request headers to ensure proper routing in complex deployment scenarios and enterprise environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Baristation/baristation-frontend/pull/26)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->