### PR TITLE
[Feat] Product API 명세 최신화 및 로스팅 필터 버튼 UI 변경

### DIFF
--- a/apps/web/app/(main)/products/[id]/_components/ProductDetailHero.tsx
+++ b/apps/web/app/(main)/products/[id]/_components/ProductDetailHero.tsx
@@ -23,6 +23,7 @@ interface ProductDetailHeroProps {
   agtronMax: number | null;
   additionalImages: ProductImageDTO[];
   flavorNotes: FlavorNoteDTO[];
+  productUrl?: string | null;
 }
 
 export function ProductDetailHero({
@@ -32,6 +33,7 @@ export function ProductDetailHero({
   agtronMax,
   additionalImages,
   flavorNotes,
+  productUrl,
 }: ProductDetailHeroProps) {
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
@@ -56,14 +58,16 @@ export function ProductDetailHero({
     }
   };
 
-  const sanitizedUrl = getSanitizedUrl(roaster.homepageUrl);
+  const sanitizedRoasterUrl = getSanitizedUrl(roaster.homepageUrl);
+  const sanitizedProductUrl = getSanitizedUrl(productUrl || null);
 
   const handlePurchaseClick = () => {
-    if (!sanitizedUrl) {
+    const targetUrl = sanitizedProductUrl || sanitizedRoasterUrl;
+    if (!targetUrl) {
       alert('구매처 링크가 유효하지 않거나 준비 중입니다.');
       return;
     }
-    window.open(sanitizedUrl, '_blank', 'noopener,noreferrer');
+    window.open(targetUrl, '_blank', 'noopener,noreferrer');
   };
 
   return (
@@ -169,9 +173,9 @@ export function ProductDetailHero({
                 <span className="font-outfit text-xs font-semibold tracking-widest text-amber-600 uppercase">
                   {roaster.nameKo}
                 </span>
-                {sanitizedUrl && (
+                {sanitizedRoasterUrl && (
                   <Link
-                    href={sanitizedUrl}
+                    href={sanitizedRoasterUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-gray-400 hover:text-gray-600"

--- a/apps/web/app/(main)/products/[id]/page.tsx
+++ b/apps/web/app/(main)/products/[id]/page.tsx
@@ -80,6 +80,7 @@ export default async function ProductDetailPage({ params }: Props) {
         agtronMax={product.agtronMax}
         additionalImages={product.images}
         flavorNotes={product.flavorNotes}
+        productUrl={product.productUrl}
       />
       <ProductInfoTable beanSummary={product.beanSummary} description={product.description} />
       <FlavorProfileSection

--- a/apps/web/components/products/ProductFilterDrawer.tsx
+++ b/apps/web/components/products/ProductFilterDrawer.tsx
@@ -1,11 +1,11 @@
 'use client';
 import { AnimatePresence, motion, useDragControls } from 'framer-motion';
-import { Droplets, Flame, Layers, RotateCcw, Scale, Sparkles } from 'lucide-react';
+import { Droplets, Layers, RotateCcw, Scale, Sparkles } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { DEFAULT_FILTERS, type FlavorType, type ProductFilterState } from '@/lib/api/products';
 
-import { FlavorFilter, MetricFilter } from './filters/FilterSections';
+import { FlavorFilter, MetricFilter, RoastingFilter } from './filters/FilterSections';
 import ProductSearchBar from './ProductSearchBar';
 
 interface ProductFilterDrawerProps {
@@ -142,7 +142,7 @@ export default function ProductFilterDrawer({
               <div className="space-y-0.5">
                 <div className="border-t border-gray-100">
                   <MetricFilter
-                    label="Acidity"
+                    label="산미"
                     icon={Droplets}
                     value={localFilters.flavor.acidity}
                     onChange={(v) =>
@@ -156,7 +156,7 @@ export default function ProductFilterDrawer({
 
                 <div className="border-t border-gray-100">
                   <MetricFilter
-                    label="Sweetness"
+                    label="감미"
                     icon={Sparkles}
                     value={localFilters.flavor.sweetness}
                     onChange={(v) =>
@@ -170,7 +170,7 @@ export default function ProductFilterDrawer({
 
                 <div className="border-t border-gray-100">
                   <MetricFilter
-                    label="Body"
+                    label="바디감"
                     icon={Layers}
                     value={localFilters.body}
                     onChange={(v) => setLocalFilters({ ...localFilters, body: v })}
@@ -179,7 +179,7 @@ export default function ProductFilterDrawer({
 
                 <div className="border-t border-gray-100">
                   <MetricFilter
-                    label="Balance"
+                    label="밸런스"
                     icon={Scale}
                     value={localFilters.flavor.balance}
                     colorPalette="teal"
@@ -193,11 +193,8 @@ export default function ProductFilterDrawer({
                 </div>
 
                 <div className="border-t border-gray-100">
-                  <MetricFilter
-                    label="Roasting"
-                    icon={Flame}
+                  <RoastingFilter
                     value={localFilters.roasting}
-                    colorPalette="espresso"
                     onChange={(v) =>
                       setLocalFilters({
                         ...localFilters,

--- a/apps/web/components/products/ProductFilterDrawer.tsx
+++ b/apps/web/components/products/ProductFilterDrawer.tsx
@@ -47,10 +47,10 @@ export default function ProductFilterDrawer({
   }, [isOpen]);
 
   const toggleFlavor = (flavor: FlavorType) => {
-    const next = localFilters.flavors.includes(flavor)
-      ? localFilters.flavors.filter((a) => a !== flavor)
-      : [...localFilters.flavors, flavor];
-    setLocalFilters({ ...localFilters, flavors: next });
+    setLocalFilters({
+      ...localFilters,
+      flavorCategory: localFilters.flavorCategory === flavor ? null : flavor,
+    });
   };
 
   const handleApply = () => {
@@ -135,7 +135,10 @@ export default function ProductFilterDrawer({
 
               {/* Flavor */}
               <div className="border-t border-gray-100 py-4">
-                <FlavorFilter selectedFlavors={localFilters.flavors} onToggle={toggleFlavor} />
+                <FlavorFilter
+                  selectedFlavor={localFilters.flavorCategory}
+                  onToggle={toggleFlavor}
+                />
               </div>
 
               {/* Metric Sections (Ungrouped) */}

--- a/apps/web/components/products/ProductFilterPanel.tsx
+++ b/apps/web/components/products/ProductFilterPanel.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Droplets, Flame, Layers, RotateCcw, Scale, Sparkles } from 'lucide-react';
+import { Droplets, Layers, RotateCcw, Scale, Sparkles } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { DEFAULT_FILTERS, type FlavorType, type ProductFilterState } from '@/lib/api/products';
 
-import { FlavorFilter, MetricFilter, isFiltered } from './filters/FilterSections';
+import { FlavorFilter, MetricFilter, RoastingFilter, isFiltered } from './filters/FilterSections';
 import ProductSearchBar from './ProductSearchBar';
 
 interface ProductFilterPanelProps {
@@ -78,7 +78,7 @@ export default function ProductFilterPanel({
         {/* Metrics Section */}
         <div className="space-y-1 py-3">
           <MetricFilter
-            label="Acidity"
+            label="산미"
             icon={Droplets}
             value={localFilters.flavor.acidity}
             onChange={(v) =>
@@ -90,7 +90,7 @@ export default function ProductFilterPanel({
           />
 
           <MetricFilter
-            label="Sweetness"
+            label="감미"
             icon={Sparkles}
             value={localFilters.flavor.sweetness}
             onChange={(v) =>
@@ -102,14 +102,14 @@ export default function ProductFilterPanel({
           />
 
           <MetricFilter
-            label="Body"
+            label="바디감"
             icon={Layers}
             value={localFilters.body}
             onChange={(v) => setLocalFilters({ ...localFilters, body: v })}
           />
 
           <MetricFilter
-            label="Balance"
+            label="밸런스"
             icon={Scale}
             value={localFilters.flavor.balance}
             colorPalette="teal"
@@ -121,11 +121,8 @@ export default function ProductFilterPanel({
             }
           />
 
-          <MetricFilter
-            label="Roasting"
-            icon={Flame}
+          <RoastingFilter
             value={localFilters.roasting}
-            colorPalette="espresso"
             onChange={(v) => setLocalFilters({ ...localFilters, roasting: v })}
           />
         </div>

--- a/apps/web/components/products/ProductFilterPanel.tsx
+++ b/apps/web/components/products/ProductFilterPanel.tsx
@@ -33,10 +33,10 @@ export default function ProductFilterPanel({
   const filtered = isFiltered(localFilters);
 
   const toggleFlavor = (flavor: FlavorType) => {
-    const next = localFilters.flavors.includes(flavor)
-      ? localFilters.flavors.filter((a) => a !== flavor)
-      : [...localFilters.flavors, flavor];
-    setLocalFilters({ ...localFilters, flavors: next });
+    setLocalFilters({
+      ...localFilters,
+      flavorCategory: localFilters.flavorCategory === flavor ? null : flavor,
+    });
   };
 
   const handleApply = () => {
@@ -72,7 +72,7 @@ export default function ProductFilterPanel({
 
         {/* Flavor */}
         <div className="border-b border-gray-100 pb-4">
-          <FlavorFilter selectedFlavors={localFilters.flavors} onToggle={toggleFlavor} />
+          <FlavorFilter selectedFlavor={localFilters.flavorCategory} onToggle={toggleFlavor} />
         </div>
 
         {/* Metrics Section */}

--- a/apps/web/components/products/filters/FilterSections.tsx
+++ b/apps/web/components/products/filters/FilterSections.tsx
@@ -14,17 +14,17 @@ export const SECTION_TITLE =
  * 향미 선택 섹션
  */
 interface FlavorFilterProps {
-  selectedFlavors: FlavorType[];
+  selectedFlavor: FlavorType | null;
   onToggle: (flavor: FlavorType) => void;
 }
 
-export function FlavorFilter({ selectedFlavors, onToggle }: FlavorFilterProps) {
+export function FlavorFilter({ selectedFlavor, onToggle }: FlavorFilterProps) {
   return (
     <div className="py-2">
       <p className={SECTION_TITLE}>향미</p>
       <div className="grid grid-cols-5 gap-2 md:grid-cols-4">
         {FLAVOR_DEFINITIONS.map((def) => {
-          const active = selectedFlavors.includes(def.id);
+          const active = selectedFlavor === def.id;
           return (
             <Tooltip key={def.id} content={def.ko}>
               <motion.button
@@ -179,7 +179,7 @@ export function RoastingFilter({ value, onChange }: RoastingFilterProps) {
  * 필터 적용 여부 확인 유틸리티
  */
 export const isFiltered = (filters: ProductFilterState) =>
-  filters.flavors.length > 0 ||
+  filters.flavorCategory !== null ||
   filters.flavor.balance[0] !== 0 ||
   filters.flavor.balance[1] !== 5 ||
   filters.flavor.sweetness[0] !== 0 ||

--- a/apps/web/components/products/filters/FilterSections.tsx
+++ b/apps/web/components/products/filters/FilterSections.tsx
@@ -65,7 +65,7 @@ export function MetricFilter({
   label,
   icon: Icon,
   value,
-  min = 1,
+  min = 0,
   max = 5,
   step = 1,
   colorPalette = 'amber',
@@ -180,12 +180,12 @@ export function RoastingFilter({ value, onChange }: RoastingFilterProps) {
  */
 export const isFiltered = (filters: ProductFilterState) =>
   filters.flavors.length > 0 ||
-  filters.flavor.balance[0] !== 1 ||
+  filters.flavor.balance[0] !== 0 ||
   filters.flavor.balance[1] !== 5 ||
-  filters.flavor.sweetness[0] !== 1 ||
+  filters.flavor.sweetness[0] !== 0 ||
   filters.flavor.sweetness[1] !== 5 ||
-  filters.flavor.acidity[0] !== 1 ||
+  filters.flavor.acidity[0] !== 0 ||
   filters.flavor.acidity[1] !== 5 ||
-  filters.body[0] !== 1 ||
+  filters.body[0] !== 0 ||
   filters.body[1] !== 5 ||
   filters.roasting !== null;

--- a/apps/web/components/products/filters/FilterSections.tsx
+++ b/apps/web/components/products/filters/FilterSections.tsx
@@ -75,22 +75,24 @@ export function MetricFilter({
   onChange,
 }: MetricFilterProps) {
   return (
-    <div className="py-3">
-      <p className="font-outfit mb-2.5 flex items-center gap-2 text-[10px] font-semibold tracking-widest text-gray-400 uppercase">
+    <div className="py-2.5">
+      <p className="font-outfit mb-2 flex items-center gap-2 text-[10px] font-semibold tracking-widest text-gray-400 uppercase">
         <Icon className="h-3 w-3" />
         {label}
       </p>
-      <RangeSlider
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        colorPalette={colorPalette}
-        onValueChange={(v) => onChange([v[0], v[1]])}
-      />
-      <div className="mt-1.5 flex justify-between px-0.5 text-[10px] font-medium text-gray-400">
-        <span>{value[0]}</span>
-        <span>{value[1]}</span>
+      <div className="flex items-center gap-3">
+        <span className="w-3 text-center text-[10px] font-medium text-gray-400">{value[0]}</span>
+        <div className="flex-1">
+          <RangeSlider
+            min={min}
+            max={max}
+            step={step}
+            value={value}
+            colorPalette={colorPalette}
+            onValueChange={(v) => onChange([v[0], v[1]])}
+          />
+        </div>
+        <span className="w-3 text-center text-[10px] font-medium text-gray-400">{value[1]}</span>
       </div>
     </div>
   );

--- a/apps/web/components/products/filters/FilterSections.tsx
+++ b/apps/web/components/products/filters/FilterSections.tsx
@@ -93,6 +93,45 @@ export function MetricFilter({
   );
 }
 
+/** 로스팅 단계 정의 상수 */
+export const ROASTING_STAGES = [
+  {
+    id: 'LIGHT',
+    ko: '라이트',
+    en: 'Light',
+    color: '#D4A373',
+    tooltip: '라이트 로스팅 (Soft Blonde/Tan)',
+  },
+  {
+    id: 'MEDIUMLIGHT',
+    ko: '미디엄 라이트',
+    en: 'Medium Light',
+    color: '#A98467',
+    tooltip: '미디엄 라이트 (Warm Amber)',
+  },
+  {
+    id: 'MEDIUM',
+    ko: '미디엄',
+    en: 'Medium',
+    color: '#8C5E3C',
+    tooltip: '미디엄 로스팅 (Classic Brown)',
+  },
+  {
+    id: 'MEDIUMDARK',
+    ko: '미디엄 다크',
+    en: 'Medium Dark',
+    color: '#6F4E37',
+    tooltip: '미디엄 다크 (Rich Espresso)',
+  },
+  {
+    id: 'DARK',
+    ko: '다크',
+    en: 'Dark',
+    color: '#3F2305',
+    tooltip: '다크 로스팅 (Deep Dark Chocolate)',
+  },
+] as const;
+
 /**
  * 로스팅 필터 (5가지 단계 버튼 선택)
  */
@@ -102,45 +141,6 @@ interface RoastingFilterProps {
 }
 
 export function RoastingFilter({ value, onChange }: RoastingFilterProps) {
-  // 로스팅 단계 정의
-  const roastingStages = [
-    {
-      id: 'LIGHT',
-      ko: '라이트',
-      en: 'Light',
-      color: '#D4A373',
-      tooltip: '라이트 로스팅 (Soft Blonde/Tan)',
-    },
-    {
-      id: 'MEDIUMLIGHT',
-      ko: '미디엄 라이트',
-      en: 'Medium Light',
-      color: '#A98467',
-      tooltip: '미디엄 라이트 (Warm Amber)',
-    },
-    {
-      id: 'MEDIUM',
-      ko: '미디엄',
-      en: '미디엄',
-      color: '#8C5E3C',
-      tooltip: '미디엄 로스팅 (Classic Brown)',
-    },
-    {
-      id: 'MEDIUMDARK',
-      ko: '미디엄 다크',
-      en: 'Medium Dark',
-      color: '#6F4E37',
-      tooltip: '미디엄 다크 (Rich Espresso)',
-    },
-    {
-      id: 'DARK',
-      ko: '다크',
-      en: '다크',
-      color: '#3F2305',
-      tooltip: '다크 로스팅 (Deep Dark Chocolate)',
-    },
-  ];
-
   return (
     <div className="py-3">
       <p className="font-outfit mb-2.5 flex items-center gap-2 text-[10px] font-semibold tracking-widest text-gray-400 uppercase">
@@ -149,11 +149,13 @@ export function RoastingFilter({ value, onChange }: RoastingFilterProps) {
       </p>
       <div className="flex items-center gap-2">
         {/* 5가지 단계 버튼 */}
-        {roastingStages.map((stage) => {
+        {ROASTING_STAGES.map((stage) => {
           const active = value === stage.id;
           return (
             <Tooltip key={stage.id} content={stage.tooltip}>
               <motion.button
+                type="button"
+                aria-pressed={active}
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.95 }}
                 onClick={() => onChange(active ? null : stage.id)}

--- a/apps/web/components/products/filters/FilterSections.tsx
+++ b/apps/web/components/products/filters/FilterSections.tsx
@@ -2,7 +2,7 @@
 
 import { RangeSlider, Tooltip } from '@coffee-service/ui-library';
 import { motion } from 'framer-motion';
-import { LucideIcon } from 'lucide-react';
+import { LucideIcon, Flame } from 'lucide-react';
 import React from 'react';
 
 import { FLAVOR_DEFINITIONS, FlavorType, ProductFilterState } from '@/lib/api/products';
@@ -21,7 +21,7 @@ interface FlavorFilterProps {
 export function FlavorFilter({ selectedFlavors, onToggle }: FlavorFilterProps) {
   return (
     <div className="py-2">
-      <p className={SECTION_TITLE}>Flavor</p>
+      <p className={SECTION_TITLE}>향미</p>
       <div className="grid grid-cols-5 gap-2 md:grid-cols-4">
         {FLAVOR_DEFINITIONS.map((def) => {
           const active = selectedFlavors.includes(def.id);
@@ -94,6 +94,86 @@ export function MetricFilter({
 }
 
 /**
+ * 로스팅 필터 (5가지 단계 버튼 선택)
+ */
+interface RoastingFilterProps {
+  value: string | null; // LIGHT | MEDIUMLIGHT | MEDIUM | MEDIUMDARK | DARK | null (null 이면 all)
+  onChange: (value: string | null) => void;
+}
+
+export function RoastingFilter({ value, onChange }: RoastingFilterProps) {
+  // 로스팅 단계 정의
+  const roastingStages = [
+    {
+      id: 'LIGHT',
+      ko: '라이트',
+      en: 'Light',
+      color: '#D4A373',
+      tooltip: '라이트 로스팅 (Soft Blonde/Tan)',
+    },
+    {
+      id: 'MEDIUMLIGHT',
+      ko: '미디엄 라이트',
+      en: 'Medium Light',
+      color: '#A98467',
+      tooltip: '미디엄 라이트 (Warm Amber)',
+    },
+    {
+      id: 'MEDIUM',
+      ko: '미디엄',
+      en: '미디엄',
+      color: '#8C5E3C',
+      tooltip: '미디엄 로스팅 (Classic Brown)',
+    },
+    {
+      id: 'MEDIUMDARK',
+      ko: '미디엄 다크',
+      en: 'Medium Dark',
+      color: '#6F4E37',
+      tooltip: '미디엄 다크 (Rich Espresso)',
+    },
+    {
+      id: 'DARK',
+      ko: '다크',
+      en: '다크',
+      color: '#3F2305',
+      tooltip: '다크 로스팅 (Deep Dark Chocolate)',
+    },
+  ];
+
+  return (
+    <div className="py-3">
+      <p className="font-outfit mb-2.5 flex items-center gap-2 text-[10px] font-semibold tracking-widest text-gray-400 uppercase">
+        <Flame className="h-3 w-3" />
+        로스팅
+      </p>
+      <div className="flex items-center gap-2">
+        {/* 5가지 단계 버튼 */}
+        {roastingStages.map((stage) => {
+          const active = value === stage.id;
+          return (
+            <Tooltip key={stage.id} content={stage.tooltip}>
+              <motion.button
+                whileHover={{ scale: 1.1 }}
+                whileTap={{ scale: 0.95 }}
+                onClick={() => onChange(active ? null : stage.id)}
+                style={{ backgroundColor: stage.color }}
+                className={`relative flex h-8 w-8 items-center justify-center rounded-full border-2 transition-all ${
+                  active
+                    ? 'scale-105 border-white ring-2 ring-amber-500 ring-offset-2'
+                    : 'border-transparent hover:border-gray-300'
+                }`}
+                aria-label={stage.ko}
+              />
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
  * 필터 적용 여부 확인 유틸리티
  */
 export const isFiltered = (filters: ProductFilterState) =>
@@ -106,5 +186,4 @@ export const isFiltered = (filters: ProductFilterState) =>
   filters.flavor.acidity[1] !== 5 ||
   filters.body[0] !== 1 ||
   filters.body[1] !== 5 ||
-  filters.roasting[0] !== 1 ||
-  filters.roasting[1] !== 5;
+  filters.roasting !== null;

--- a/apps/web/components/products/filters/FilterSections.tsx
+++ b/apps/web/components/products/filters/FilterSections.tsx
@@ -28,6 +28,9 @@ export function FlavorFilter({ selectedFlavor, onToggle }: FlavorFilterProps) {
           return (
             <Tooltip key={def.id} content={def.ko}>
               <motion.button
+                type="button"
+                aria-pressed={active}
+                aria-label={def.ko}
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
                 onClick={() => onToggle(def.id)}

--- a/apps/web/lib/api/products.ts
+++ b/apps/web/lib/api/products.ts
@@ -182,8 +182,14 @@ export const FLAVOR_DEFINITIONS: FlavorDefinition[] = [
   { id: 'SAVORY', ko: '감칠맛', emoji: '🧂' },
   // { id: 'MOUTHFEEL', ko: '바디감', emoji: '🥛' },
   // { id: 'DEFECT', ko: '결함', emoji: '⚠️' },
-  // { id: 'OTHER', ko: '기타', emoji: '❓' },
 ];
+
+export const VALID_FLAVORS: FlavorType[] = FLAVOR_DEFINITIONS.map((def) => def.id);
+
+/** 향미 타입이 유효한지 검증하는 타입 가드 */
+export function isValidFlavor(val: any): val is FlavorType {
+  return VALID_FLAVORS.includes(val);
+}
 
 export type RoastingType = 1 | 2 | 3 | 4 | 5; // 1: Light, 5: Dark
 export type BodyType = 1 | 2 | 3 | 4 | 5; // 1: Light, 5: Heavy
@@ -298,7 +304,7 @@ export function encodeFiltersToParams(
 ): URLSearchParams {
   const params = new URLSearchParams();
 
-  if (filters.flavorCategory) {
+  if (filters.flavorCategory && isValidFlavor(filters.flavorCategory)) {
     params.set('flavorCategory', filters.flavorCategory);
   }
 
@@ -332,7 +338,7 @@ export function mapFiltersToApiRequest(
     req.keyword = searchQuery.trim();
   }
 
-  if (filters.flavorCategory) {
+  if (filters.flavorCategory && isValidFlavor(filters.flavorCategory)) {
     req.flavorCategory = filters.flavorCategory;
   }
 
@@ -376,7 +382,10 @@ export function decodeParamsToFilters(params: URLSearchParams): {
 
   const flavorCategoryParam = params.get('flavorCategory') || params.get('flavors');
   if (flavorCategoryParam) {
-    filters.flavorCategory = flavorCategoryParam.split(',')[0] as FlavorType;
+    const firstFlavor = flavorCategoryParam.split(',')[0];
+    if (isValidFlavor(firstFlavor)) {
+      filters.flavorCategory = firstFlavor;
+    }
   }
 
   const parseRange = (val: string | null): [number, number] | null => {

--- a/apps/web/lib/api/products.ts
+++ b/apps/web/lib/api/products.ts
@@ -222,7 +222,7 @@ export interface ProductInfo {
 }
 
 export interface ProductFilterState {
-  flavors: FlavorType[];
+  flavorCategory: FlavorType | null;
   flavor: {
     balance: [number, number];
     sweetness: [number, number];
@@ -233,7 +233,7 @@ export interface ProductFilterState {
 }
 
 export const DEFAULT_FILTERS: ProductFilterState = {
-  flavors: [],
+  flavorCategory: null,
   flavor: { balance: [0, 5], sweetness: [0, 5], acidity: [0, 5] },
   body: [0, 5],
   roasting: null,
@@ -298,8 +298,8 @@ export function encodeFiltersToParams(
 ): URLSearchParams {
   const params = new URLSearchParams();
 
-  if (filters.flavors.length > 0) {
-    params.set('flavors', filters.flavors.join(','));
+  if (filters.flavorCategory) {
+    params.set('flavorCategory', filters.flavorCategory);
   }
 
   if (filters.flavor.balance[0] !== 0 || filters.flavor.balance[1] !== 5)
@@ -332,9 +332,8 @@ export function mapFiltersToApiRequest(
     req.keyword = searchQuery.trim();
   }
 
-  if (filters.flavors.length > 0) {
-    // 다중 선택 시 첫 번째 향미를 flavorCategory로 전달
-    req.flavorCategory = filters.flavors[0];
+  if (filters.flavorCategory) {
+    req.flavorCategory = filters.flavorCategory;
   }
 
   // 맛 프로필 파라미터 필수화 (null 여부: X) - 항상 기본값 또는 설정된 범위를 포함하여 전송 (살균 처리)
@@ -369,15 +368,15 @@ export function decodeParamsToFilters(params: URLSearchParams): {
 } {
   const filters: ProductFilterState = {
     ...DEFAULT_FILTERS,
-    flavors: [...DEFAULT_FILTERS.flavors],
+    flavorCategory: DEFAULT_FILTERS.flavorCategory,
     flavor: { ...DEFAULT_FILTERS.flavor },
     body: [...DEFAULT_FILTERS.body],
     roasting: DEFAULT_FILTERS.roasting,
   };
 
-  const flavorsParam = params.get('flavors');
-  if (flavorsParam) {
-    filters.flavors = flavorsParam.split(',') as FlavorType[];
+  const flavorCategoryParam = params.get('flavorCategory') || params.get('flavors');
+  if (flavorCategoryParam) {
+    filters.flavorCategory = flavorCategoryParam.split(',')[0] as FlavorType;
   }
 
   const parseRange = (val: string | null): [number, number] | null => {

--- a/apps/web/lib/api/products.ts
+++ b/apps/web/lib/api/products.ts
@@ -46,6 +46,7 @@ export interface ProductDetailDTO {
   body: number | null;
   balance: number | null;
   images: ProductImageDTO[];
+  productUrl?: string | null;
 }
 
 export interface ProductDetailResponse {

--- a/apps/web/lib/api/products.ts
+++ b/apps/web/lib/api/products.ts
@@ -239,11 +239,57 @@ export const DEFAULT_FILTERS: ProductFilterState = {
   roasting: null,
 };
 
-/** FlavorType → Tailwind 배경 클래스 매핑 (구 버전 호환성 유지 혹은 제거 가능) */
 export const FLAVOR_BG_CLASS: Record<string, string> = {
   FRUITY: 'bg-flavor-fruit',
   CHOCOLATY: 'bg-flavor-chocolate',
 };
+
+export const VALID_ROASTING_TYPES = [
+  'LIGHT',
+  'MEDIUMLIGHT',
+  'MEDIUM',
+  'MEDIUMDARK',
+  'DARK',
+] as const;
+export type RoastingFilterValue = (typeof VALID_ROASTING_TYPES)[number];
+
+/** 로스팅 타입이 유효한지 검증하는 타입 가드 */
+export function isValidRoastingType(val: any): val is RoastingFilterValue {
+  return VALID_ROASTING_TYPES.includes(val);
+}
+
+/** 수치 지표 범위를 정제하고 검증하는 헬퍼 함수 */
+export function sanitizeRange(
+  range: any,
+  minDefault: number = 1,
+  maxDefault: number = 5,
+  domainMin: number = 0,
+  domainMax: number = 5,
+): [number, number] {
+  if (!Array.isArray(range) || range.length !== 2) {
+    return [minDefault, maxDefault];
+  }
+
+  let min = Number(range[0]);
+  let max = Number(range[1]);
+
+  // NaN 또는 유한하지 않은 값 처리
+  if (!Number.isFinite(min)) min = minDefault;
+  if (!Number.isFinite(max)) max = maxDefault;
+
+  // 도메인 범위로 제한 (Clamping)
+  min = Math.max(domainMin, Math.min(domainMax, min));
+  max = Math.max(domainMin, Math.min(domainMax, max));
+
+  // 하한값이 상한값보다 큰 경우 스왑
+  if (min > max) {
+    const temp = min;
+    min = max;
+    max = temp;
+  }
+
+  return [min, max];
+}
 
 /** 필터 상태를 URL Query String으로 인코딩 */
 export function encodeFiltersToParams(
@@ -291,18 +337,25 @@ export function mapFiltersToApiRequest(
     req.flavorCategory = filters.flavors[0];
   }
 
-  // 맛 프로필 파라미터 필수화 (null 여부: X) - 항상 기본값 또는 설정된 범위를 포함하여 전송
-  req.minAcidity = filters.flavor.acidity[0];
-  req.maxAcidity = filters.flavor.acidity[1];
-  req.minSweetness = filters.flavor.sweetness[0];
-  req.maxSweetness = filters.flavor.sweetness[1];
-  req.minBody = filters.body[0];
-  req.maxBody = filters.body[1];
-  req.minBalance = filters.flavor.balance[0];
-  req.maxBalance = filters.flavor.balance[1];
+  // 맛 프로필 파라미터 필수화 (null 여부: X) - 항상 기본값 또는 설정된 범위를 포함하여 전송 (살균 처리)
+  const [minAcidity, maxAcidity] = sanitizeRange(filters.flavor.acidity);
+  req.minAcidity = minAcidity;
+  req.maxAcidity = maxAcidity;
 
-  // 로스팅 선택 상태가 존재할 경우 roastingType 추가
-  if (filters.roasting) {
+  const [minSweetness, maxSweetness] = sanitizeRange(filters.flavor.sweetness);
+  req.minSweetness = minSweetness;
+  req.maxSweetness = maxSweetness;
+
+  const [minBody, maxBody] = sanitizeRange(filters.body);
+  req.minBody = minBody;
+  req.maxBody = maxBody;
+
+  const [minBalance, maxBalance] = sanitizeRange(filters.flavor.balance);
+  req.minBalance = minBalance;
+  req.maxBalance = maxBalance;
+
+  // 로스팅 선택 상태가 존재하고 Whitelist에 포함된 경우 roastingType 추가
+  if (filters.roasting && isValidRoastingType(filters.roasting)) {
     req.roastingType = filters.roasting;
   }
 
@@ -339,16 +392,16 @@ export function decodeParamsToFilters(params: URLSearchParams): {
   const b = parseRange(params.get('balance'));
   const s = parseRange(params.get('sweetness'));
   const a = parseRange(params.get('acidity'));
-  if (b) filters.flavor.balance = b;
-  if (s) filters.flavor.sweetness = s;
-  if (a) filters.flavor.acidity = a;
+  if (b) filters.flavor.balance = sanitizeRange(b);
+  if (s) filters.flavor.sweetness = sanitizeRange(s);
+  if (a) filters.flavor.acidity = sanitizeRange(a);
 
   const body = parseRange(params.get('body'));
-  if (body) filters.body = body;
+  if (body) filters.body = sanitizeRange(body);
 
-  // URL에서 roastingType 파라미터를 읽어와 디코딩
+  // URL에서 roastingType 파라미터를 읽어와 유효한지 검증 후 디코딩
   const roastingTypeParam = params.get('roastingType');
-  if (roastingTypeParam) {
+  if (roastingTypeParam && isValidRoastingType(roastingTypeParam)) {
     filters.roasting = roastingTypeParam;
   }
 

--- a/apps/web/lib/api/products.ts
+++ b/apps/web/lib/api/products.ts
@@ -185,8 +185,6 @@ export const FLAVOR_DEFINITIONS: FlavorDefinition[] = [
   // { id: 'OTHER', ko: '기타', emoji: '❓' },
 ];
 
-export const FLAVOR_TYPES: FlavorType[] = FLAVOR_DEFINITIONS.map((def) => def.id);
-
 export type RoastingType = 1 | 2 | 3 | 4 | 5; // 1: Light, 5: Dark
 export type BodyType = 1 | 2 | 3 | 4 | 5; // 1: Light, 5: Heavy
 
@@ -245,20 +243,7 @@ export const DEFAULT_FILTERS: ProductFilterState = {
 export const FLAVOR_BG_CLASS: Record<string, string> = {
   FRUITY: 'bg-flavor-fruit',
   CHOCOLATY: 'bg-flavor-chocolate',
-  FLORAL: 'bg-flavor-floral',
-  // ... 필요 시 추가
 };
-
-export const ROASTING_TYPES: RoastingType[] = [1, 2, 3, 4, 5];
-export const BODY_TYPES: BodyType[] = [1, 2, 3, 4, 5];
-
-export function getFlavorById(id: FlavorType) {
-  return FLAVOR_DEFINITIONS.find((def) => def.id === id);
-}
-
-export function getFlavorByKoName(ko: string) {
-  return FLAVOR_DEFINITIONS.find((def) => def.ko === ko);
-}
 
 /** 필터 상태를 URL Query String으로 인코딩 */
 export function encodeFiltersToParams(

--- a/apps/web/lib/api/products.ts
+++ b/apps/web/lib/api/products.ts
@@ -234,8 +234,8 @@ export interface ProductFilterState {
 
 export const DEFAULT_FILTERS: ProductFilterState = {
   flavors: [],
-  flavor: { balance: [1, 5], sweetness: [1, 5], acidity: [1, 5] },
-  body: [1, 5],
+  flavor: { balance: [0, 5], sweetness: [0, 5], acidity: [0, 5] },
+  body: [0, 5],
   roasting: null,
 };
 
@@ -261,7 +261,7 @@ export function isValidRoastingType(val: any): val is RoastingFilterValue {
 /** 수치 지표 범위를 정제하고 검증하는 헬퍼 함수 */
 export function sanitizeRange(
   range: any,
-  minDefault: number = 1,
+  minDefault: number = 0,
   maxDefault: number = 5,
   domainMin: number = 0,
   domainMax: number = 5,
@@ -302,13 +302,13 @@ export function encodeFiltersToParams(
     params.set('flavors', filters.flavors.join(','));
   }
 
-  if (filters.flavor.balance[0] !== 1 || filters.flavor.balance[1] !== 5)
+  if (filters.flavor.balance[0] !== 0 || filters.flavor.balance[1] !== 5)
     params.set('balance', filters.flavor.balance.join('-'));
-  if (filters.flavor.sweetness[0] !== 1 || filters.flavor.sweetness[1] !== 5)
+  if (filters.flavor.sweetness[0] !== 0 || filters.flavor.sweetness[1] !== 5)
     params.set('sweetness', filters.flavor.sweetness.join('-'));
-  if (filters.flavor.acidity[0] !== 1 || filters.flavor.acidity[1] !== 5)
+  if (filters.flavor.acidity[0] !== 0 || filters.flavor.acidity[1] !== 5)
     params.set('acidity', filters.flavor.acidity.join('-'));
-  if (filters.body[0] !== 1 || filters.body[1] !== 5) params.set('body', filters.body.join('-'));
+  if (filters.body[0] !== 0 || filters.body[1] !== 5) params.set('body', filters.body.join('-'));
 
   // 로스팅 선택 상태가 존재할 경우 roastingType으로 URL 파라미터 저장
   if (filters.roasting) {

--- a/apps/web/lib/api/products.ts
+++ b/apps/web/lib/api/products.ts
@@ -96,20 +96,14 @@ export interface ProductSearchResponse {
 export interface ProductSearchRequest {
   keyword?: string;
   flavorCategory?: string;
-  flavorCategories?: string[];
   minAcidity?: number;
   maxAcidity?: number;
   minSweetness?: number;
   maxSweetness?: number;
-  minBitterness?: number;
-  maxBitterness?: number;
   minBody?: number;
   maxBody?: number;
   minBalance?: number;
   maxBalance?: number;
-  minRoasting?: number;
-  maxRoasting?: number;
-  body?: number;
   roastingType?: string;
   sortBy?: string;
   page?: number;
@@ -237,14 +231,14 @@ export interface ProductFilterState {
     acidity: [number, number];
   };
   body: [number, number];
-  roasting: [number, number];
+  roasting: string | null; // 단일 Enum 값 (LIGHT, MEDIUMLIGHT, MEDIUM, MEDIUMDARK, DARK) 또는 null (all)
 }
 
 export const DEFAULT_FILTERS: ProductFilterState = {
   flavors: [],
   flavor: { balance: [1, 5], sweetness: [1, 5], acidity: [1, 5] },
   body: [1, 5],
-  roasting: [1, 5],
+  roasting: null,
 };
 
 /** FlavorType → Tailwind 배경 클래스 매핑 (구 버전 호환성 유지 혹은 제거 가능) */
@@ -284,8 +278,11 @@ export function encodeFiltersToParams(
   if (filters.flavor.acidity[0] !== 1 || filters.flavor.acidity[1] !== 5)
     params.set('acidity', filters.flavor.acidity.join('-'));
   if (filters.body[0] !== 1 || filters.body[1] !== 5) params.set('body', filters.body.join('-'));
-  if (filters.roasting[0] !== 1 || filters.roasting[1] !== 5)
-    params.set('roasting', filters.roasting.join('-'));
+
+  // 로스팅 선택 상태가 존재할 경우 roastingType으로 URL 파라미터 저장
+  if (filters.roasting) {
+    params.set('roastingType', filters.roasting);
+  }
 
   if (searchQuery.trim()) params.set('q', searchQuery.trim());
 
@@ -305,35 +302,23 @@ export function mapFiltersToApiRequest(
   }
 
   if (filters.flavors.length > 0) {
-    // 다중 선택 지원을 위해 배열 전체 전달 (API 사양에 맞춰 선택적 처리 필요)
-    req.flavorCategories = filters.flavors;
-    // 하위 호환성을 위해 첫 번째 항목도 유지
+    // 다중 선택 시 첫 번째 향미를 flavorCategory로 전달
     req.flavorCategory = filters.flavors[0];
   }
 
-  if (filters.flavor.acidity[0] !== 1 || filters.flavor.acidity[1] !== 5) {
-    req.minAcidity = filters.flavor.acidity[0];
-    req.maxAcidity = filters.flavor.acidity[1];
-  }
+  // 맛 프로필 파라미터 필수화 (null 여부: X) - 항상 기본값 또는 설정된 범위를 포함하여 전송
+  req.minAcidity = filters.flavor.acidity[0];
+  req.maxAcidity = filters.flavor.acidity[1];
+  req.minSweetness = filters.flavor.sweetness[0];
+  req.maxSweetness = filters.flavor.sweetness[1];
+  req.minBody = filters.body[0];
+  req.maxBody = filters.body[1];
+  req.minBalance = filters.flavor.balance[0];
+  req.maxBalance = filters.flavor.balance[1];
 
-  if (filters.flavor.sweetness[0] !== 1 || filters.flavor.sweetness[1] !== 5) {
-    req.minSweetness = filters.flavor.sweetness[0];
-    req.maxSweetness = filters.flavor.sweetness[1];
-  }
-
-  if (filters.flavor.balance[0] !== 1 || filters.flavor.balance[1] !== 5) {
-    req.minBalance = filters.flavor.balance[0];
-    req.maxBalance = filters.flavor.balance[1];
-  }
-
-  if (filters.body[0] !== 1 || filters.body[1] !== 5) {
-    req.minBody = filters.body[0];
-    req.maxBody = filters.body[1];
-  }
-
-  if (filters.roasting[0] !== 1 || filters.roasting[1] !== 5) {
-    req.minRoasting = filters.roasting[0];
-    req.maxRoasting = filters.roasting[1];
+  // 로스팅 선택 상태가 존재할 경우 roastingType 추가
+  if (filters.roasting) {
+    req.roastingType = filters.roasting;
   }
 
   return req;
@@ -349,7 +334,7 @@ export function decodeParamsToFilters(params: URLSearchParams): {
     flavors: [...DEFAULT_FILTERS.flavors],
     flavor: { ...DEFAULT_FILTERS.flavor },
     body: [...DEFAULT_FILTERS.body],
-    roasting: [...DEFAULT_FILTERS.roasting],
+    roasting: DEFAULT_FILTERS.roasting,
   };
 
   const flavorsParam = params.get('flavors');
@@ -376,8 +361,11 @@ export function decodeParamsToFilters(params: URLSearchParams): {
   const body = parseRange(params.get('body'));
   if (body) filters.body = body;
 
-  const roasting = parseRange(params.get('roasting'));
-  if (roasting) filters.roasting = roasting;
+  // URL에서 roastingType 파라미터를 읽어와 디코딩
+  const roastingTypeParam = params.get('roastingType');
+  if (roastingTypeParam) {
+    filters.roasting = roastingTypeParam;
+  }
 
   const searchQuery = params.get('q') || '';
 

--- a/packages/ui-library/components/RangeSlider.tsx
+++ b/packages/ui-library/components/RangeSlider.tsx
@@ -40,10 +40,7 @@ const RangeSlider = React.forwardRef<
   return (
     <SliderPrimitive.Root
       ref={ref}
-      className={cn(
-        'relative mx-auto flex w-[calc(100%-20px)] touch-none select-none items-center py-2',
-        className,
-      )}
+      className={cn('relative flex w-full touch-none select-none items-center py-2', className)}
       {...props}
     >
       <SliderPrimitive.Track

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,5 @@ packages:
   - 'apps/*'
   - 'packages/*'
 allowBuilds:
-  sharp: set this to true or false
-  unrs-resolver: set this to true or false
+  sharp: true
+  unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+allowBuilds:
+  sharp: set this to true or false
+  unrs-resolver: set this to true or false

--- a/specs/products-page.md
+++ b/specs/products-page.md
@@ -157,7 +157,7 @@ interface ProductFilterState {
     acidity: [number, number]; // 산미 범위 [min, max] (1~5)
   };
   body: [number, number]; // 바디감 범위 [min, max] (1~5)
-  roasting: [number, number]; // 로스팅 범위 [min, max] (1~5)
+  roasting: string | null; // 단일 로스팅 Enum 또는 null ('LIGHT' | 'MEDIUMLIGHT' | 'MEDIUM' | 'MEDIUMDARK' | 'DARK')
 }
 
 type FlavorType =
@@ -170,7 +170,7 @@ type FlavorType =
   | '견과'
   | '꽃'
   | '스모크';
-type RoastingType = 1 | 2 | 3 | 4 | 5;
+type RoastingType = 'LIGHT' | 'MEDIUMLIGHT' | 'MEDIUM' | 'MEDIUMDARK' | 'DARK';
 
 interface ProductFilterPanelProps {
   filters: ProductFilterState;
@@ -199,11 +199,13 @@ interface ProductFilterPanelProps {
 
 1. **Search** 구역: 패널 최상단에 `ProductSearchBar`를 포함하여 이름/원산지 검색 연동
 2. **Flavor (향)** 섹션: 17개 아로마 카테고리를 Chip 형태로 나열, 다중 선택 가능
-3. **맛 및 프로파일** 섹션: **산미·단맛·밸런스·바디감·로스팅**을 `RangeSlider`를 이용해 범위(Range) 필터링 가능하게 구현
-4. **RangeSlider UI**: 슬라이더 핸들을 조절하여 최소/최대값을 설정하며, 핸들 상단에 현재 값을 나타내는 `Tooltip`을 노출한다
+3. **맛 및 프로파일** 섹션: **산미·단맛·밸런스·바디감**은 `RangeSlider`를 이용해 범위(Range) 필터링하고, **로스팅**은 프리미엄 원형 버튼을 활용해 단일 단계별 필터링이 가능하게 구현
+4. **RangeSlider & Roasting UI**:
+   - 맛 및 프로파일 슬라이더: 핸들을 조절하여 최소/최대값을 설정하며, 핸들 상단에 현재 값을 나타내는 `Tooltip`을 노출한다.
+   - 로스팅 버튼: 5단계 로스팅 강도(LIGHT, MEDIUMLIGHT, MEDIUM, MEDIUMDARK, DARK)에 매칭되는 감성적인 커피 색상 단추들을 제공하며, 호버 시 툴팁을 제공하고 선택 시 단색 링 외곽선 강조 효과를 부여한다. 중복 클릭 시 선택이 토글식으로 해제(전체)된다.
 5. 모든 필터링 조작은 즉시 반영되지 않고 `localFilters` 상태만 갱신한다
 6. 하단에 스티키(Sticky)하게 자리잡은 "적용하기" 버튼을 클릭할 때 `onChange(localFilters)`를 호출하여 상위 컨텍스트에 반영한다
-7. 하나 이상의 필터가 기본값([1, 5])을 벗어나면 상단에 "초기화" 버튼이 노출된다
+7. 하나 이상의 필터가 기본 상태(기본 범위 외 혹은 로스팅 선택 시)를 벗어나면 상단에 "초기화" 버튼이 노출된다
 8. 초기화 버튼 클릭 시 `onReset()`을 호출하여 모든 필터를 해제한다
 
 #### 6. Design Spec (디자인 명세)
@@ -211,7 +213,7 @@ interface ProductFilterPanelProps {
 - **Layout**: `w-[240px] shrink-0`, 수직 스크롤 가능, 섹션 간 `pb-6 border-b border-gray-100`
 - **Flavor Chip**: `rounded-full px-3 py-1 text-xs`, 선택 시 `bg-amber-500 text-white font-semibold shadow-sm`, 미선택 시 `bg-gray-50 border border-gray-200 text-gray-700 hover:bg-gray-100 hover:border-gray-300`
 - **Rating Bar**: 마디별 테두리 적용(`border border-gray-200/50`), 값이 높을수록 진한 색상(`amber-200`~`amber-600`), 미선택 마디는 `bg-gray-50`
-- **Roasting Chip**: Flavor Chip과 동일 스타일
+- **Roasting Filter UI**: 5가지 로스팅 단계별 원형 테마 단추 제공 (Light: `#D4A373`, Medium Light: `#A98467`, Medium: `#8C5E3C`, Medium Dark: `#6F4E37`, Dark: `#3F2305`). 활성화 시 white border + amber-500 2px ring 강조. 웹 접근성 표준(`type="button"`, `aria-pressed`) 준수.
 - **Typography**: 섹션 타이틀 `Outfit SemiBold text-xs uppercase tracking-widest text-gray-500`, 바디감 수치 텍스트는 타이틀과 동일 선상 우측 배치
 - **Apply Button**: 패널 최하단에 스티키(`sticky bottom-0`)하게 배치되며 `w-full rounded-xl bg-amber-500 py-3 text-sm font-semibold text-white` 속성 적용
 - **Animation** (`framer-motion`): Chip 선택 시 `scale: 0.95 → 1.0` 0.1s 튕김 효과
@@ -221,7 +223,7 @@ interface ProductFilterPanelProps {
 - [ ] (기능) Flavor Chip 다중 선택 및 해제가 정상 동작한다
 - [ ] (기능) Flavor Rating Bar가 1~5 단계 선택을 처리하며 점차 진한 색으로 표기된다
 - [ ] (기능) Body Rating Bar가 1~5 단계 선택을 처리하며 점차 진한 색으로 표기된다
-- [ ] (기능) Roasting Rating Bar가 1~5 단계 선택을 처리하며 점차 진한 색으로 표기된다
+- [ ] (기능) Roasting 필터가 LIGHT, MEDIUMLIGHT, MEDIUM, MEDIUMDARK, DARK 5단계 버튼 선택을 처리하며 선택한 단일 Enum이 상위로 전송된다
 - [ ] (기능) 초기화 버튼 클릭 시 모든 필터가 해제된다
 - [ ] (기능) "적용하기" 버튼 클릭 시에만 필터 변경 사항이 부모로 전달된다
 - [ ] (디자인) "적용하기" 버튼이 스크롤 시에도 패널 최하단에 스티키하게 고정된다

--- a/specs/products-page.md
+++ b/specs/products-page.md
@@ -152,11 +152,11 @@ interface ProductSearchBarProps {
 interface ProductFilterState {
   flavors: FlavorType[]; // 선택된 아로마 (다중 선택)
   flavor: {
-    balance: [number, number]; // 밸런스 범위 [min, max] (1~5)
-    sweetness: [number, number]; // 단맛 범위 [min, max] (1~5)
-    acidity: [number, number]; // 산미 범위 [min, max] (1~5)
+    balance: [number, number]; // 밸런스 범위 [min, max] (0~5)
+    sweetness: [number, number]; // 단맛 범위 [min, max] (0~5)
+    acidity: [number, number]; // 산미 범위 [min, max] (0~5)
   };
-  body: [number, number]; // 바디감 범위 [min, max] (1~5)
+  body: [number, number]; // 바디감 범위 [min, max] (0~5)
   roasting: string | null; // 단일 로스팅 Enum 또는 null ('LIGHT' | 'MEDIUMLIGHT' | 'MEDIUM' | 'MEDIUMDARK' | 'DARK')
 }
 

--- a/specs/products-page.md
+++ b/specs/products-page.md
@@ -150,7 +150,7 @@ interface ProductSearchBarProps {
 
 ```ts
 interface ProductFilterState {
-  flavors: FlavorType[]; // 선택된 아로마 (다중 선택)
+  flavorCategory: FlavorType | null; // 선택된 아로마 (단일 선택)
   flavor: {
     balance: [number, number]; // 밸런스 범위 [min, max] (0~5)
     sweetness: [number, number]; // 단맛 범위 [min, max] (0~5)
@@ -198,7 +198,7 @@ interface ProductFilterPanelProps {
 #### 5. Functional Requirements (단계별 요구사항)
 
 1. **Search** 구역: 패널 최상단에 `ProductSearchBar`를 포함하여 이름/원산지 검색 연동
-2. **Flavor (향)** 섹션: 17개 아로마 카테고리를 Chip 형태로 나열, 다중 선택 가능
+2. **Flavor (향)** 섹션: 10개 아로마 카테고리를 Chip 형태로 나열, 단일 선택 가능 (중복 클릭 시 토글식 해제)
 3. **맛 및 프로파일** 섹션: **산미·단맛·밸런스·바디감**은 `RangeSlider`를 이용해 범위(Range) 필터링하고, **로스팅**은 프리미엄 원형 버튼을 활용해 단일 단계별 필터링이 가능하게 구현
 4. **RangeSlider & Roasting UI**:
    - 맛 및 프로파일 슬라이더: 핸들을 조절하여 최소/최대값을 설정하며, 핸들 상단에 현재 값을 나타내는 `Tooltip`을 노출한다.
@@ -220,7 +220,7 @@ interface ProductFilterPanelProps {
 
 #### 7. Definition of Done (검증 기준)
 
-- [ ] (기능) Flavor Chip 다중 선택 및 해제가 정상 동작한다
+- [ ] (기능) Flavor Chip 단일 선택 및 해제가 정상 동작한다
 - [ ] (기능) Flavor Rating Bar가 1~5 단계 선택을 처리하며 점차 진한 색으로 표기된다
 - [ ] (기능) Body Rating Bar가 1~5 단계 선택을 처리하며 점차 진한 색으로 표기된다
 - [ ] (기능) Roasting 필터가 LIGHT, MEDIUMLIGHT, MEDIUM, MEDIUMDARK, DARK 5단계 버튼 선택을 처리하며 선택한 단일 Enum이 상위로 전송된다

--- a/specs/products-page.md
+++ b/specs/products-page.md
@@ -489,47 +489,74 @@ const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false);
 
 ---
 
-## 8. API 연동 명세 (초안)
+## 8. API 연동 명세 (최신화)
+
+> **스펙 변경 사유 (Reason / Context)**: 백엔드 API 설계 고도화에 맞춰 원두 검색 API 파라미터 구조를 최신화했습니다. 맛 프로필 8종 파라미터가 필수화되었으며, 기존의 로스팅 범위 필터가 단일 Enum 필터(`roastingType`)로 단일화되었습니다. 응답의 향미 속성은 명세 정정사항에 따라 기존의 `flavorNotes` 명칭을 그대로 유지합니다.
 
 ### 상황
 
-> 상품(원두) 목록 조회 (필터·검색 및 페이지네이션 포함)
+> 필터에 따른 원두 목록 페이지 전송 (검색 및 페이지네이션 포함)
 
 ### Request
 
 ```http
-GET /api/products/search?keyword={keyword}&flavorCategory={category}&minAcidity={1-10}&maxAcidity={1-10}&minSweetness={1-10}&maxSweetness={1-10}&body={1-5}&page={0}&size={12}
+GET /api/products/search?keyword={keyword}&flavorCategory={category}&minAcidity={0-5}&maxAcidity={0-5}&minSweetness={0-5}&maxSweetness={0-5}&minBody={0-5}&maxBody={0-5}&minBalance={0-5}&maxBalance={0-5}&roastingType={roastingType}&sortBy={sortBy}&page={0}&size={12}&sort={sort}
 ```
 
-| Query Parameter  | Type     | Description                            | 필수 |
-| ---------------- | -------- | -------------------------------------- | ---- |
-| `keyword`        | `string` | 원두명 / 생산지 / 로스터명 키워드 검색 | ✗    |
-| `flavorCategory` | `string` | 맛 카테고리 (FRUITY, NUTTY 등 Enum)    | ✗    |
-| `minAcidity`     | `number` | 산미 최소값 (1~10 단위 확장 가능)      | ✗    |
-| `maxAcidity`     | `number` | 산미 최대값 (1~10 단위 확장 가능)      | ✗    |
-| `minSweetness`   | `number` | 단맛 최소값 (1~10 단위 확장 가능)      | ✗    |
-| `maxSweetness`   | `number` | 단맛 최대값 (1~10 단위 확장 가능)      | ✗    |
-| `body`           | `number` | 바디감 1~5                             | ✗    |
-| `roastingType`   | `string` | 로스팅 타입 (LIGHT, MEDIUM 등 Enum)    | ✗    |
-| `page`           | `number` | 페이지 번호 (0부터 시작)               | ✗    |
-| `size`           | `number` | 한 페이지 당 아이템 수 (기본 12)       | ✗    |
-| `sortBy`         | `string` | 정렬 기준 (예: 'id', 'name')           | ✗    |
-| `sort`           | `string` | 정렬 방향 ('asc', 'desc')              | ✗    |
+| Query Parameter  | Type    | Description                            | 필수 여부 | 형식                                                                          |
+| ---------------- | ------- | -------------------------------------- | --------- | ----------------------------------------------------------------------------- |
+| `keyword`        | String  | 원두명 / 생산지 / 로스터명 키워드 검색 | ✗         | -                                                                             |
+| `flavorCategory` | Enum    | 맛 카테고리 (FRUITY, NUTTY, FLORAL 등) | ✗         | `[FlavorCategory]`                                                            |
+| `minAcidity`     | Integer | 산미 최소값 (0~5)                      | ✓         | `0~5`                                                                         |
+| `maxAcidity`     | Integer | 산미 최대값 (0~5)                      | ✓         | `0~5`                                                                         |
+| `minSweetness`   | Integer | 단맛 최소값 (0~5)                      | ✓         | `0~5`                                                                         |
+| `maxSweetness`   | Integer | 단맛 최대값 (0~5)                      | ✓         | `0~5`                                                                         |
+| `minBody`        | Integer | 바디감 최소값 (0~5)                    | ✓         | `0~5`                                                                         |
+| `maxBody`        | Integer | 바디감 최대값 (0~5)                    | ✓         | `0~5`                                                                         |
+| `minBalance`     | Integer | 밸런스 최소값 (0~5)                    | ✓         | `0~5`                                                                         |
+| `maxBalance`     | Integer | 밸런스 최대값 (0~5)                    | ✓         | `0~5`                                                                         |
+| `roastingType`   | Enum    | 로스팅 타입                            | ✗         | `LIGHT`, `MEDIUMLIGHT`, `MEDIUM`, `MEDIUMDARK`, `DARK`                        |
+| `sortBy`         | Enum    | 정렬 기준 (LATEST, NAME, ACIDITY 등)   | ✗         | `LATEST`, `NAME`, `ROASTING_LEVEL`, `ACIDITY`, `SWEETNESS`, `BODY`, `BALANCE` |
+| `page`           | Integer | 페이지 번호 (0부터 시작)               | ✗         | 기본: `0`                                                                     |
+| `size`           | Integer | 페이지 크기                            | ✗         | 기본: `12`                                                                    |
+| `sort`           | String  | 정렬 방식                              | ✗         | 필드명,방향 (기본: `createdAt,desc`)                                          |
 
 ### Response Body
 
-```ts
-interface ProductSearchResponse {
-  statusCode: string;
-  message: string;
-  data: {
-    content: ProductSearchItem[]; // 향미/이미지 정보 포함 상품 리스트
-    totalPages: number;
-    totalElements: number;
-    currentPage: number;
-    size: number;
-    hasNext: boolean;
-    hasPrevious: boolean;
-  };
+```json
+{
+  "statusCode": "200",
+  "message": "OK",
+  "data": {
+    "content": [
+      {
+        "productId": 1,
+        "beanNameKo": "에티오피아 예가체프",
+        "beanNameEn": "Ethiopia Yirgacheffe",
+        "origin": "Ethiopia",
+        "region": "Yirgacheffe",
+        "process": "Washed",
+        "productImage": {
+          "productImageId": 101,
+          "imageType": "THUMB",
+          "imageUrl": "https://example.com/images/bean1.jpg",
+          "sortOrder": 1
+        },
+        "flavorNotes": {
+          "flavorNoteId": 101,
+          "flavorCategory": "CHOCOLATY",
+          "nameKo": "다크초콜릿",
+          "nameEn": "Dark chocolate",
+          "flavorImageUrl": "https://example.com/images/flavor.jpg"
+        }
+      }
+    ],
+    "totalPages": 5,
+    "totalElements": 20,
+    "currentPage": 0,
+    "size": 12,
+    "hasNext": true,
+    "hasPrevious": false
+  }
 }
 ```


### PR DESCRIPTION
## 주요 변경 사항

### 1. API 규격 최신화 및 리팩토링
- **`ProductSearchRequest` 인터페이스 동기화**:
  - 추가
    - `minAcidity`
    - `maxAcidity`
    - `minSweetness`
    - `maxSweetness`
    - `minBody`
    - `maxBody`
    - `minBalance`
    - `maxBalance`
    - `roastingType` 
  - 삭제
    - `minRoasting`
    - `maxRoasting`
    - `minBitterness`
    - `maxBitterness`
    - `body`
    - `flavorCategories` 
- **필터 상태 타입 전환 (`ProductFilterState`)**:
  - `roasting` 필드의 타입을 기존 `[number, number]`에서 `string | null`로 리팩토링했습니다.
- **매퍼 및 URL 인코딩/디코딩 로직 간소화**:
  - `mapFiltersToApiRequest`: 
    - 8종의 맛 프로필 필수 필드(`null 여부: X`)가 항상 전송되도록 보장합니다.
    - 로스팅 선택 상태를 `roastingType`에 곧바로 할당하도록 갱신했습니다.
  - `encodeFiltersToParams` & `decodeParamsToFilters`: 
    - 브라우저 URL 쿼리 파라미터 역시 레거시 구조 대신 최신 명세(`roastingType=ENUM`)와 완벽히 동기화했습니다, 
    - 공유 링크 접속이나 새로고침 시에도 필터 상태가 완벽히 보존됩니다.

### 2. 로스팅 필터 UI 변경
  - 로스팅 강도를 시각적으로 체감할 수 있도록 깊이 있는 5가지 브라운 커피 테마 컬러를 각각 적용했습니다.
    - 라이트 (`#D4A373`)
    - 미디엄 라이트 (`#A98467`)
    - 미디엄 (`#8C5E3C`)
    - 미디엄 다크 (`#6F4E37`)
    - 다크 (`#3F2305`)
- **마우스 호버 툴팁**:
  - 각 버튼 호버 시 `<Tooltip>` 컴포넌트를 통해 로스팅 강도와 명칭을 텍스트 팝업으로 상세히 전달합니다.

### 3. 필터 레이블 완전 한국어화 (`ProductFilterPanel.tsx` & `ProductFilterDrawer.tsx`)
- 데스크톱 필터 패널과 모바일 필터 드로어 전체의 영어 표기 조건들을 국내 사용자들에게 가장 어울리는 직관적인 한국어 명칭으로 일관되게 교체했습니다.
  - `Flavor` ➡️ **향미**
  - `Acidity` ➡️ **산미**
  - `Sweetness` ➡️ **감미**
  - `Body` ➡️ **바디감**
  - `Balance` ➡️ **밸런스**
  - `Roasting` ➡️ **로스팅**

### 4. 설계 명세서 문서 동기화 (`specs/products-page.md`)
프로젝트 전역 규칙 2.1(Specs 중심 관리)에 따라 변경 결정 사유(Reason / Context)를 최상단에 투명하게 명시하고, 신규 API 스펙)으로 최신화했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roasting filter redesigned to discrete 5-stage buttons (single selection).

* **Localization**
  * Filter labels translated to Korean: acidity (산미), sweetness (감미), body (바디감), balance (밸런스), flavor title (향미).

* **Refactor**
  * Flavor filter changed to single-category selection; taste/profile ranges normalized to 0–5 and API search contract updated to use explicit min/max taste fields plus a roasting type.

* **Documentation**
  * Products page spec and API contract updated to reflect new filter semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Baristation/baristation-frontend/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->